### PR TITLE
Update translation_transformer.py

### DIFF
--- a/beginner_source/translation_transformer.py
+++ b/beginner_source/translation_transformer.py
@@ -21,6 +21,8 @@ This tutorial shows:
 #
 # To access torchtext datasets, please install torchdata following instructions at https://github.com/pytorch/data.
 #
+# Make sure to install portalock (dependency) by before importing dataset from torchtext.datasets.
+# !pip install portalock
 
 from torchtext.data.utils import get_tokenizer
 from torchtext.vocab import build_vocab_from_iterator


### PR DESCRIPTION
Introduction documentation must mention the portalock library dependency that needs to be installed before importing the dataset from torchtext.datasets. If not installed, it results in an error when running the notebook in Google Colab. Issue has the following stackoverflow post https://stackoverflow.com/questions/76302971/question-in-pytorch-transformer-tutorial-about-nonetype-object-has-no-attribut 

This change is also recommended for the ipynb notebook at https://pytorch.org/tutorials/beginner/translation_transformer.html

Fixes #ISSUE_NUMBER 1

## Description
<!---1. Added comments to install portalock dependency to avoid attibute error -->

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ x] Only one issue is addressed in this pull request
- [ x] Labels from the issue that this PR is fixing are added to this pull request
- [ x] No unnecessary issues are included into this pull request.
